### PR TITLE
Add support for scoped modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,5 +6,10 @@ module.exports = function (file) {
   var segments = file.split(path.sep)
   var index = segments.lastIndexOf('node_modules')
   if (index === -1) return
-  return segments[index + 1]
+  var moduleName = segments[index + 1]
+  // check for scoped modules
+  if (moduleName[0] === '@') {
+    moduleName = segments[index + 1] + path.sep + segments[index + 2]
+  }
+  return moduleName
 }

--- a/test.js
+++ b/test.js
@@ -3,14 +3,24 @@
 var assert = require('assert')
 var parse = require('./')
 
-var paths = [
+var simplePaths = [
   '/path/to/node_modules/name/index.js',
   '/path/to/node_modules/name/sub/index.js',
   '/path/to/node_modules/invalid/node_modules/name/index.js'
 ]
 
-paths.forEach(function (path) {
+simplePaths.forEach(function (path) {
   assert.strictEqual(parse(path), 'name')
+})
+
+var scopedPaths = [
+  '/path/to/node_modules/@org/name/index.js',
+  '/path/to/node_modules/@org/name/sub/index.js',
+  '/path/to/node_modules/invalid/node_modules/@org/name/index.js'
+]
+
+scopedPaths.forEach(function (path) {
+  assert.strictEqual(parse(path), '@org/name')
 })
 
 assert.strictEqual(parse(''), undefined)


### PR DESCRIPTION
Npm introduced scoped modules (eg `@babel/parser`) which confuses your module.
With scoped modules the actual module is nested in a directory that corresponds to the org name (e.g `@babel`)